### PR TITLE
Add lossless playback option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [core] Add `SpotifyUri` type to represent more types of URI than `SpotifyId` can
+- [playback] Add lossless bitrate option to select FLAC audio when available
 
 ### Changed
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -12,11 +12,14 @@ use crate::{
     },
     model::{LoadRequest, PlayingTrack, SpircPlayStatus},
     playback::{
+        config::Bitrate,
         mixer::Mixer,
         player::{Player, PlayerEvent, PlayerEventChannel},
     },
     protocol::{
-        connect::{Cluster, ClusterUpdate, LogoutCommand, SetVolumeCommand},
+        connect::{
+            CapabilitySupportDetails, Cluster, ClusterUpdate, LogoutCommand, SetVolumeCommand,
+        },
         context::Context,
         explicit_content_pubsub::UserAttributesUpdate,
         playlist4_external::PlaylistModificationInfo,
@@ -168,7 +171,16 @@ impl Spirc {
         let spirc_id = SPIRC_COUNTER.fetch_add(1, Ordering::AcqRel);
         debug!("new Spirc[{spirc_id}]");
 
-        let connect_state = ConnectState::new(config, &session);
+        let mut connect_state = ConnectState::new(config, &session);
+        if player.bitrate() == Bitrate::Lossless {
+            let supports_hifi = CapabilitySupportDetails {
+                fully_supported: true,
+                user_eligible: true,
+                device_supported: true,
+                ..Default::default()
+            };
+            connect_state.set_supported_audio_quality(AudioQuality::HIFI, Some(supports_hifi));
+        }
 
         let connection_id_update = session
             .dealer()

--- a/connect/src/state.rs
+++ b/connect/src/state.rs
@@ -14,7 +14,10 @@ use crate::{
     },
     model::SpircPlayStatus,
     protocol::{
-        connect::{Capabilities, Device, DeviceInfo, MemberType, PutStateReason, PutStateRequest},
+        connect::{
+            Capabilities, CapabilitySupportDetails, Device, DeviceInfo, MemberType, PutStateReason,
+            PutStateRequest,
+        },
         media::AudioQuality,
         player::{
             ContextIndex, ContextPlayerOptions, PlayOrigin, PlayerState, ProvidedTrack,
@@ -277,6 +280,26 @@ impl ConnectState {
             .as_mut()
             .expect("the device_info has to be always given")
             .volume = volume;
+    }
+
+    pub fn set_supported_audio_quality(
+        &mut self,
+        quality: AudioQuality,
+        supports_hifi: Option<CapabilitySupportDetails>,
+    ) {
+        let capabilities = self
+            .device_mut()
+            .device_info
+            .as_mut()
+            .expect("the device_info has to be always given")
+            .capabilities
+            .as_mut()
+            .expect("capabilities are configured during initialization");
+
+        capabilities.supported_audio_quality = EnumOrUnknown::new(quality);
+        capabilities.supports_hifi = supports_hifi
+            .map(MessageField::some)
+            .unwrap_or_else(MessageField::none);
     }
 
     pub fn set_last_command(&mut self, command: Request) {

--- a/metadata/src/audio/file.rs
+++ b/metadata/src/audio/file.rs
@@ -101,7 +101,10 @@ impl AudioFiles {
     }
 
     pub fn is_flac(format: AudioFileFormat) -> bool {
-        matches!(format, AudioFileFormat::FLAC_FLAC)
+        matches!(
+            format,
+            AudioFileFormat::FLAC_FLAC | AudioFileFormat::FLAC_FLAC_24BIT
+        )
     }
 }
 

--- a/playback/src/config.rs
+++ b/playback/src/config.rs
@@ -8,6 +8,7 @@ pub enum Bitrate {
     Bitrate96,
     Bitrate160,
     Bitrate320,
+    Lossless,
 }
 
 impl FromStr for Bitrate {
@@ -17,6 +18,7 @@ impl FromStr for Bitrate {
             "96" => Ok(Self::Bitrate96),
             "160" => Ok(Self::Bitrate160),
             "320" => Ok(Self::Bitrate320),
+            s if s.eq_ignore_ascii_case("lossless") => Ok(Self::Lossless),
             _ => Err(()),
         }
     }

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -53,6 +53,7 @@ pub type PlayerResult = Result<(), Error>;
 pub struct Player {
     commands: Option<mpsc::UnboundedSender<PlayerCommand>>,
     thread_handle: Option<thread::JoinHandle<()>>,
+    bitrate: Bitrate,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
@@ -437,6 +438,7 @@ impl Player {
         F: FnOnce() -> Box<dyn Sink> + Send + 'static,
     {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let bitrate = config.bitrate;
 
         if config.normalisation {
             debug!("Normalisation Type: {:?}", config.normalisation_type);
@@ -509,6 +511,7 @@ impl Player {
         Arc::new(Self {
             commands: Some(cmd_tx),
             thread_handle: Some(handle),
+            bitrate,
         })
     }
 
@@ -517,6 +520,10 @@ impl Player {
             return handle.is_finished();
         }
         true
+    }
+
+    pub fn bitrate(&self) -> Bitrate {
+        self.bitrate
     }
 
     fn command(&self, cmd: PlayerCommand) {
@@ -933,7 +940,7 @@ impl PlayerTrackLoader {
             AudioFileFormat::XHE_AAC_12 => 1.5,
             AudioFileFormat::XHE_AAC_16 => 2.,
             AudioFileFormat::XHE_AAC_24 => 3.,
-            AudioFileFormat::FLAC_FLAC_24BIT => 3.,
+            AudioFileFormat::FLAC_FLAC_24BIT => 224., // assume ~1.8 Mbit/s on average
         };
         let data_rate: f32 = kbps * 1024.;
         Some(data_rate.ceil() as usize)
@@ -991,8 +998,8 @@ impl PlayerTrackLoader {
         );
 
         // (Most) podcasts seem to support only 96 kbps Ogg Vorbis, so fall back to it
-        let formats = match self.config.bitrate {
-            Bitrate::Bitrate96 => [
+        let formats: &[AudioFileFormat] = match self.config.bitrate {
+            Bitrate::Bitrate96 => &[
                 AudioFileFormat::OGG_VORBIS_96,
                 AudioFileFormat::MP3_96,
                 AudioFileFormat::OGG_VORBIS_160,
@@ -1001,7 +1008,7 @@ impl PlayerTrackLoader {
                 AudioFileFormat::OGG_VORBIS_320,
                 AudioFileFormat::MP3_320,
             ],
-            Bitrate::Bitrate160 => [
+            Bitrate::Bitrate160 => &[
                 AudioFileFormat::OGG_VORBIS_160,
                 AudioFileFormat::MP3_160,
                 AudioFileFormat::OGG_VORBIS_96,
@@ -1010,7 +1017,18 @@ impl PlayerTrackLoader {
                 AudioFileFormat::OGG_VORBIS_320,
                 AudioFileFormat::MP3_320,
             ],
-            Bitrate::Bitrate320 => [
+            Bitrate::Bitrate320 => &[
+                AudioFileFormat::OGG_VORBIS_320,
+                AudioFileFormat::MP3_320,
+                AudioFileFormat::MP3_256,
+                AudioFileFormat::OGG_VORBIS_160,
+                AudioFileFormat::MP3_160,
+                AudioFileFormat::OGG_VORBIS_96,
+                AudioFileFormat::MP3_96,
+            ],
+            Bitrate::Lossless => &[
+                AudioFileFormat::FLAC_FLAC_24BIT,
+                AudioFileFormat::FLAC_FLAC,
                 AudioFileFormat::OGG_VORBIS_320,
                 AudioFileFormat::MP3_320,
                 AudioFileFormat::MP3_256,

--- a/src/main.rs
+++ b/src/main.rs
@@ -444,7 +444,7 @@ async fn get_setup() -> Setup {
     .optopt(
         BITRATE_SHORT,
         BITRATE,
-        "Bitrate (kbps) {96|160|320}. Defaults to 160.",
+        "Bitrate {96|160|320|lossless}. Defaults to 160.",
         "BITRATE",
     )
     .optopt(
@@ -1564,7 +1564,13 @@ async fn get_setup() -> Setup {
             .as_deref()
             .map(|bitrate| {
                 Bitrate::from_str(bitrate).unwrap_or_else(|_| {
-                    invalid_error_msg(BITRATE, BITRATE_SHORT, bitrate, "96, 160, 320", "160");
+                    invalid_error_msg(
+                        BITRATE,
+                        BITRATE_SHORT,
+                        bitrate,
+                        "96, 160, 320, lossless",
+                        "160",
+                    );
                     exit(1);
                 })
             })


### PR DESCRIPTION
## Summary
- add a `lossless` bitrate option to the CLI and player configuration so FLAC streams are selected when available
- advertise HiFi capability for Connect devices when lossless playback is enabled and treat 24-bit FLAC as a supported format

## Testing
- cargo fmt
- cargo check *(fails: missing system library `alsa` for `alsa-sys` build script)*

------
https://chatgpt.com/codex/tasks/task_e_68e4be667fe8832ba74071cebcfd70b0